### PR TITLE
Feat/TripDate: 여행 기간 선택 Storage 모든 날짜 저장 로직 구현

### DIFF
--- a/src/components/common/TripRegionDaysEdit.tsx
+++ b/src/components/common/TripRegionDaysEdit.tsx
@@ -1,10 +1,10 @@
-import { DaysStore } from "@/store/DaysStore";
+import { DatesStore } from "@/store/DatesStore";
 import { RegionStore } from "@/store/RegionStore";
-import { getTripDateKo } from "@/utils/getTripDay";
+import { getTripDate } from "@/utils/getTripDate";
 
 const TripRegionDaysEdit = () => {
   const { selectedRegionName } = RegionStore();
-  const { tripDays } = DaysStore();
+  const { tripDates } = DatesStore();
 
   // 모달창 구현 예정
   const toggleTripEdit = () => {};
@@ -12,10 +12,15 @@ const TripRegionDaysEdit = () => {
   return (
     <aside className="flex justify-between items-center w-full h-20 px-5 bg-contentSecondary">
       <div>
-        <p className="text-white">{selectedRegionName || "여행 지역"}</p>
+        <p className="text-white">
+          {selectedRegionName
+            ? selectedRegionName
+            : "여행 지역을 다시 선택해주세요."}
+        </p>
         <p className=" text-white">
-          {`${getTripDateKo(tripDays[0])} ~
-          ${getTripDateKo(tripDays[1])}` || "여행 기간"}
+          {tripDates
+            ? `${getTripDate(tripDates[0])} - ${getTripDate(tripDates[tripDates.length - 1])}`
+            : "여행 기간을 다시 선택해주세요."}
         </p>
       </div>
       <button

--- a/src/components/tripdate/TripCalendar.tsx
+++ b/src/components/tripdate/TripCalendar.tsx
@@ -1,0 +1,29 @@
+import Calendar from "react-calendar";
+import { DatesStore } from "@/store/DatesStore";
+import "@/styles/calendar.css";
+
+export const TripCalendar = () => {
+  const { setTripDates } = DatesStore();
+
+  return (
+    <Calendar
+      className={"h-[19.875rem w-[19.875rem] p-[1.3475rem] text-content"}
+      locale="ko"
+      onChange={(value) => setTripDates(value)}
+      selectRange={true}
+      formatMonthYear={(_, date) =>
+        `${date.getFullYear()}.${date.getMonth() + 1}`
+      }
+      formatDay={(_, date) => date.toLocaleString("en", { day: "numeric" })}
+      minDetail="year"
+      maxDetail="month"
+      next2Label={null}
+      prev2Label={null}
+      prevAriaLabel={"전 달로 이동"}
+      nextAriaLabel={"다음 달로 이동"}
+      tileDisabled={({ date }) =>
+        date < new Date(new Date().setDate(new Date().getDate() - 1))
+      }
+    />
+  );
+};

--- a/src/components/tripdate/TripDateInfo.tsx
+++ b/src/components/tripdate/TripDateInfo.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import Image from "next/image";
+import { DatesStore } from "@/store/DatesStore";
+
+type TripDateInfoProps = {
+  contents: string;
+  isPoint?: boolean;
+};
+
+export const TripDateInfo = ({
+  contents,
+  isPoint = false,
+}: TripDateInfoProps) => {
+  const { tripDates } = DatesStore();
+  let title = "여행 제목";
+
+  if (Boolean(tripDates)) {
+    title = "선택한 여행 기간";
+    isPoint = true;
+  } else {
+    title = "오늘 날짜";
+  }
+
+  const imageSrc =
+    "/svg/" +
+    (title == "다가오는 여행"
+      ? "plane-paper.svg"
+      : Boolean(tripDates)
+        ? "calendar-selected.svg"
+        : "calendar-inSelected.svg");
+
+  return (
+    <div className="flex flex-col gap-y-[0.3125rem] min-w-80 py-[0.625rem]">
+      <div className="flex gap-[0.3125rem]">
+        <Image src={imageSrc} alt={title} width={24} height={24} />
+        <span
+          className={`${isPoint ? "text-content" : "text-contentSecondary"} font-bold`}
+          aria-hidden
+        >
+          {title}
+        </span>
+      </div>
+      <p
+        className={`ml-[0.3125rem] ${isPoint ? "text-[#2966E3]" : "text-contentMuted"}`}
+      >
+        {contents}
+      </p>
+    </div>
+  );
+};

--- a/src/components/tripdate/TripScheduleInfo.tsx
+++ b/src/components/tripdate/TripScheduleInfo.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Image from "next/image";
+
+type TripScheduleInfoProps = {
+  isPoint?: boolean;
+  isContents?: boolean;
+};
+
+export const TripScheduleInfo = ({
+  isPoint = false,
+  isContents = false,
+}: TripScheduleInfoProps) => {
+  // 여행 일정 있을시 isPoint = true 로직 처리 예정
+
+  return (
+    <div className="flex flex-col gap-y-[0.3125rem] min-w-80 py-[0.625rem]">
+      <div className="flex gap-[0.3125rem]">
+        <Image
+          src="/svg/plane-paper.svg"
+          alt="다가오는 여행"
+          width={24}
+          height={24}
+        />
+        <span
+          className={`${isPoint ? "text-content" : "text-contentSecondary"} font-bold`}
+          aria-hidden
+        >
+          다가오는 여행
+        </span>
+      </div>
+      {isContents ? (
+        <div>여행 일정이 존재합니다.</div>
+      ) : (
+        <p className="ml-[0.3125rem] text-contentMuted">
+          예정된 여행이 없습니다. (*일정 로직 처리 예정)
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/layout/tripdate/layout.tsx
+++ b/src/layout/tripdate/layout.tsx
@@ -1,0 +1,26 @@
+import "@/styles/globals.css";
+import Head from "next/head";
+
+const TripDateLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => {
+  return (
+    <>
+      <Head>
+        <title>Trip Date - WonT</title>
+        <meta name="description" content="여행 기간 선택 페이지입니다." />
+        <link rel="icon" href="/favicon/favicon.ico" />
+      </Head>
+      <section
+        className="flex flex-col items-center gap-y-[1.875rem] px-5 mb-[1.875rem]
+      "
+      >
+        {children}
+      </section>
+    </>
+  );
+};
+
+export default TripDateLayout;

--- a/src/pages/tripdate/index.tsx
+++ b/src/pages/tripdate/index.tsx
@@ -1,0 +1,43 @@
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import TripDateLayout from "@/layout/tripdate/layout";
+import HeaderTripSelect from "@/components/header/HeaderTripSelect";
+import TripTitle from "@/components/tripselect/TripTitle";
+import { TripCalendar } from "@/components/tripdate/TripCalendar";
+import { TripDateInfo } from "@/components/tripdate/TripDateInfo";
+import { TripScheduleInfo } from "@/components/tripdate/TripScheduleInfo";
+import ButtonLarge from "@/components/tripselect/ButtonLarge";
+import { DatesStore } from "@/store/DatesStore";
+import { getTripDateKo } from "@/utils/getTripDate";
+
+const TripDatePage = () => {
+  const { tripDates } = DatesStore();
+
+  const selectDaysInfoText = tripDates
+    ? `${tripDates[0]} ~ ${tripDates[tripDates.length - 1]}`
+    : getTripDateKo(new Date());
+
+  const inSelectedTripDates = () => {
+    toast.error("여행 일자를 선택해 주세요!", {
+      position: "top-center",
+      autoClose: 2500,
+    });
+  };
+
+  return (
+    <TripDateLayout>
+      <HeaderTripSelect inCloseButton />
+      <TripTitle title="언제 떠나시나요?" guide="여행 일자를 선택해 주세요." />
+      <TripCalendar />
+      <TripDateInfo contents={selectDaysInfoText} />
+      <TripScheduleInfo />
+      <ButtonLarge
+        isSelected={Boolean(tripDates)}
+        href="/tripedit"
+        onClick={inSelectedTripDates}
+      />
+    </TripDateLayout>
+  );
+};
+
+export default TripDatePage;

--- a/src/pages/tripedit/index.tsx
+++ b/src/pages/tripedit/index.tsx
@@ -1,28 +1,23 @@
+import TripRegionDaysEdit from "@/components/common/TripRegionDaysEdit";
 import SaveButton from "@/components/tripedit/SaveButton";
 import TripDays from "@/components/tripedit/TripDays";
 import TripEditMap from "@/components/tripedit/TripEditMap";
 import TripEditLayout from "@/layout/tripedit/layout";
-import { AccommodationStore } from "@/store/AccommodationStore";
+import { DatesStore } from "@/store/DatesStore";
 
 function TripEdit() {
-  const tripDate = new Date();
+  const { tripDates } = DatesStore();
+  //TODO@uniS2
+  console.log("여행일자", tripDates);
 
   //TODO@uniS2: 각 일자에 맞는 숙박 선택 정보 제공을 위한 storage 초기화
-  const clearAccommodationIdStorage = AccommodationStore.persist.clearStorage;
+  // const clearAccommodationIdStorage = AccommodationsStore.persist.clearStorage;
 
   return (
     <TripEditLayout>
       <div>
         <TripEditMap />
-        <div className="w-full h-[80px] bg-contentSecondary flex justify-between items-center px-5">
-          <div className="flex flex-col">
-            <span className="text-white">제주</span>
-            <span className="text-white">24.01.20 - 24.01.22</span>
-          </div>
-          <button className="border-[1px] w-[56px] h-7 rounded-md border-contentMuted text-contentMuted text-sm">
-            수정
-          </button>
-        </div>
+        <TripRegionDaysEdit />
         <section>
           <div className="mt-7 mb-10">
             <TripDays days="Day 1" date="24.01.20" />

--- a/src/store/DatesStore.ts
+++ b/src/store/DatesStore.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type DatesStoreType = {
+  tripDates: null | string[];
+  setTripDates: (dates: any) => void;
+};
+
+export const DatesStore = create(
+  persist<DatesStoreType>(
+    (set) => ({
+      tripDates: null,
+      setTripDates: (dates: Date[]) => set({ tripDates: getDateRange(dates) }),
+      resetTripDates: () => set({ tripDates: null }),
+    }),
+    {
+      name: "tripDatesStorage",
+    },
+  ),
+);
+
+const getDateRange = (value: Date[]) => {
+  const start = new Date(value[0]);
+  const end = new Date(value[1]);
+
+  const result = [];
+
+  while (start <= end) {
+    result.push(start.toLocaleDateString().split("T")[0].slice(0, -1));
+    start.setDate(start.getDate() + 1);
+  }
+
+  return result;
+};

--- a/src/utils/getTripDate.ts
+++ b/src/utils/getTripDate.ts
@@ -1,0 +1,29 @@
+const dayText = [
+  "일요일",
+  "월요일",
+  "화요일",
+  "수요일",
+  "목요일",
+  "금요일",
+  "토요일",
+];
+
+export function getTripDateKo(selectDate: Date) {
+  selectDate = new Date(selectDate);
+  const year = selectDate.getFullYear();
+  const month = selectDate.getMonth() + 1;
+  const date = selectDate.getDate();
+  const day = dayText[selectDate.getDay()];
+  return `${year}년 ${month}월 ${date}일 ${day}`;
+}
+
+export function getTripDate(selectDate: string) {
+  let [year, month, date] = selectDate.split(".");
+  if (Number(month) < 10) {
+    month = `0${month}`.replace(" ", "");
+  }
+  if (Number(date) < 10) {
+    date = `0${date}`.replace(" ", "");
+  }
+  return `${year.slice(2)}.${month}.${date}`;
+}


### PR DESCRIPTION
## Overview
related #59 

### 작업 내용

- `DateStore` storage `tripDates` state 모든 날짜 저장 로직 구현
  - 시작일, 종료일 배열(`Date[]`) 저장 => 모든 날짜 저장 (`string[]`)

- 유틸함수 `getTripDate()` 수정
  - `getTripDateKo()`: `0000년 0월 0일 0요일` 형식으로 반환
  - `getTripDate()`: `00.00.00` 형식으로 반환

- TripEdit 페이지 공통 컴포넌트 적용 및 여행 기간 렌더링
  - `TripRegionDaysEdit` 컴포넌트 적용
  - 11번째 줄 `console.log("여행일자", tripDates);`을 통해 확인할 수 있습니다!

### 달성도

- TripDate 페이지 로직 구현 완료했습니다.
- `PlacesStore` 및 `AccommodationsStore` storage 로직 여행 기간 일자별로 저장되도록 변경할 예정입니다.

## 레퍼런스
| TripDate 페이지_selected | DatesStore |
|:----------------------------:|:------------:|
|![TripRegionDaysEdit 컴포넌트 구현](https://github.com/Next-WonT/WonT/assets/134567469/550a3547-423a-44fa-bd94-e1acb8ee69f3)|![DatesStore ](https://github.com/Next-WonT/WonT/assets/134567469/5d316df1-c4d8-4cdf-8f60-897a09b481ec)|

## PR 체크리스트

- [x] 다음 사항을 읽고 포함하였습니다.

1. 코드 스타일은 프로젝트 규칙을 따릅니다.
2. 기능 구현의 경우, 코드는 문제없이 빌드 및 실행됩니다.
3. 새로운 기능을 테스트한 경우, 기존 기능에 영향을 미치지 않습니다.
4. 필요한 관련사항을 이슈템플릿에 추가하였습니다.
