### PR TITLE
Feat/TripPlace_Accommodation: 선택한 숙소, 관광 장소 Storage 타입 변경 (Object -> Array)

### DIFF
--- a/src/components/tripedit/AddPlanButton.tsx
+++ b/src/components/tripedit/AddPlanButton.tsx
@@ -1,9 +1,9 @@
 import MapPin from "./MapPin";
 import { AiFillPlusCircle } from "react-icons/ai";
 import { BsX } from "react-icons/bs";
-import { AccommodationsStore } from "@/store/AccommodationsStore";
+import { SelectAccommodationsStore } from "@/store/AccommodationsStore";
 import { useEffect } from "react";
-import { PlacesStore } from "@/store/PlacesStore";
+import { SelectPlacesStore } from "@/store/PlacesStore";
 
 interface AddPlanButtonProps {
   text?: string;
@@ -23,9 +23,9 @@ function AddPlanButton({
   handleRoute,
   // handleRemove
 }: AddPlanButtonProps) {
-  const { selectedAccommodations, setSelectedAccommodationArray } =
-    AccommodationsStore();
-  const { selectedPlaces, setSelectedPlacesArray } = PlacesStore();
+  const { selectedAccommodations /* setSelectedAccommodationArray */ } =
+    SelectAccommodationsStore();
+  const { selectedPlaces /* setSelectedPlacesArray */ } = SelectPlacesStore();
 
   // const handleRemove = (e: React.MouseEvent) => {
   //   const target = e.currentTarget;
@@ -42,7 +42,7 @@ function AddPlanButton({
       if (text === "장소") {
         const newSelectedPlaces = Array.from(selectedPlaces || []);
         newSelectedPlaces.splice(index, 1);
-        setSelectedPlacesArray(newSelectedPlaces);
+        // setSelectedPlacesArray(newSelectedPlaces);
       }
 
       if (text === "숙소") {
@@ -50,7 +50,7 @@ function AddPlanButton({
           selectedAccommodations || [],
         );
         newSelectedAccommodations.splice(index, 1);
-        setSelectedAccommodationArray(newSelectedAccommodations);
+        // setSelectedAccommodationArray(newSelectedAccommodations);
       }
     }
   };

--- a/src/components/tripedit/TripDays.tsx
+++ b/src/components/tripedit/TripDays.tsx
@@ -12,9 +12,9 @@ import { motion } from "framer-motion";
 import { useViewPlanStore } from "@/store/useViewPlanStore";
 import { DatesStore } from "@/store/DatesStore";
 import Router from "next/router";
-import { PlacesStore } from "@/store/PlacesStore";
+import { SelectPlacesStore } from "@/store/PlacesStore";
 import AddSchedule from "./AddSchedule";
-import { AccommodationsStore } from "@/store/AccommodationsStore";
+import { SelectAccommodationsStore } from "@/store/AccommodationsStore";
 
 interface TripDaysProps {
   days?: string;
@@ -25,9 +25,9 @@ interface TripDaysProps {
 
 function TripDays() {
   const { viewPlanStates, setViewPlanStates } = useViewPlanStore();
-  const { selectedAccommodations, setSelectedAccommodationArray } =
-    AccommodationsStore();
-  const { selectedPlaces, setSelectedPlacesArray } = PlacesStore();
+  const { selectedPlaces /* setSelectedPlacesArray */ } = SelectPlacesStore();
+  const { selectedAccommodations /* setSelectedAccommodationArray */ } =
+    SelectAccommodationsStore();
   const { tripDates } = DatesStore();
   console.log(selectedAccommodations);
   console.log(selectedPlaces);
@@ -63,7 +63,7 @@ function TripDays() {
       const [removed] = newSelectedPlaces.splice(source.index, 1);
       newSelectedPlaces.splice(destination.index, 0, removed);
 
-      setSelectedPlacesArray(newSelectedPlaces);
+      // setSelectedPlacesArray(newSelectedPlaces);
     }
   };
 

--- a/src/components/tripedit/TripEditMap.tsx
+++ b/src/components/tripedit/TripEditMap.tsx
@@ -1,5 +1,5 @@
-import { AccommodationsStore } from "@/store/AccommodationsStore";
-import { PlacesStore } from "@/store/PlacesStore";
+import { SelectAccommodationsStore } from "@/store/AccommodationsStore";
+import { SelectPlacesStore } from "@/store/PlacesStore";
 import { RegionStore } from "@/store/RegionStore";
 import { SelectedPlanStore } from "@/store/SelectedPlanStore";
 import { useTripPlaceStore } from "@/store/useTripPlaceStore";
@@ -19,8 +19,8 @@ function TripEditMap() {
   const [mapLatLngArray, setMapLatLngArray] = useState<any[]>([]);
   const { viewPlanStates, setViewPlanStates } = useViewPlanStore();
   const { selectedRegionName } = RegionStore();
-  const { selectedAccommodations } = AccommodationsStore();
-  const { selectedPlaces, setSelectedPlacesArray } = PlacesStore();
+  const { selectedAccommodations } = SelectAccommodationsStore();
+  const { selectedPlaces /* setSelectedPlacesArray */ } = SelectPlacesStore();
   const { selectedPlan, setSelectedPlan } = SelectedPlanStore();
 
   useEffect(() => {
@@ -85,7 +85,7 @@ function TripEditMap() {
 
         if (selectedAccommodations && selectedPlaces) {
           const selected = selectedAccommodations?.concat(selectedPlaces);
-          setSelectedPlan(selected);
+          // setSelectedPlan(selected);
 
           selected?.forEach((item) => {
             // 주소로 좌표를 검색합니다

--- a/src/pages/tripaccommodation/index.tsx
+++ b/src/pages/tripaccommodation/index.tsx
@@ -17,7 +17,7 @@ function TripAccommodationPage() {
   const { selectedAccommodations, resetSelectedAccommodations } =
     SelectAccommodationsStore();
   const isSelected = Boolean(selectedAccommodations);
-  const totalNumberText = Object.keys(selectedAccommodations!).length;
+  const totalNumberText = selectedAccommodations!.length;
 
   return (
     <TripAccommodationLayout>

--- a/src/pages/tripedit/index.tsx
+++ b/src/pages/tripedit/index.tsx
@@ -6,8 +6,8 @@ import { RegionStore } from "@/store/RegionStore";
 import React, { useEffect, useState } from "react";
 import { DatesStore } from "@/store/DatesStore";
 import { useRouter } from "next/router";
-import { PlacesStore } from "@/store/PlacesStore";
-import { AccommodationsStore } from "@/store/AccommodationsStore";
+import { SelectPlacesStore } from "@/store/PlacesStore";
+import { SelectAccommodationsStore } from "@/store/AccommodationsStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import supabase from "@/lib/supabase/supabase";
 import { SelectedPlanStore } from "@/store/SelectedPlanStore";
@@ -15,9 +15,9 @@ import { SelectedPlanStore } from "@/store/SelectedPlanStore";
 function TripEdit() {
   const { selectedRegionName, resetRegionName } = RegionStore();
   const { tripDates, resetTripDates } = DatesStore();
-  const { selectedAccommodations, setSelectedAccommodationArray } =
-    AccommodationsStore();
-  const { selectedPlaces, setSelectedPlacesArray } = PlacesStore();
+  const { selectedPlaces /* setSelectedPlacesArray */ } = SelectPlacesStore();
+  const { selectedAccommodations /* setSelectedAccommodationArray */ } =
+    SelectAccommodationsStore();
   const { userSession, setUserSession } = useSessionStore();
   const [userSessionId, setUserSessionId] = useState<string | undefined>();
   const { selectedPlan, setSelectedPlan } = SelectedPlanStore();
@@ -25,7 +25,7 @@ function TripEdit() {
   console.log("selectedPlan", selectedPlan);
 
   //TODO@uniS2: 각 일자에 맞는 숙박 선택 정보 제공을 위한 storage 초기화
-  // const clearAccommodationIdStorage = AccommodationStore.persist.clearStorage;
+  // const clearAccommodationIdStorage = SelectAccommodationStore.persist.clearStorage;
 
   useEffect(() => {
     const getUserSession = async () => {
@@ -39,8 +39,8 @@ function TripEdit() {
   const handleModify = () => {
     resetRegionName();
     resetTripDates();
-    setSelectedAccommodationArray([]);
-    setSelectedPlacesArray([]);
+    // setSelectedAccommodationArray([]);
+    // setSelectedPlacesArray([]);
 
     router.push("/tripregion");
   };

--- a/src/pages/tripplace/index.tsx
+++ b/src/pages/tripplace/index.tsx
@@ -13,7 +13,7 @@ const TripPlacePage = () => {
   const { locationPlaces } = LocationPlacesStore();
   const { selectedPlaces, resetSelectedPlaces } = SelectPlacesStore();
   const isSelected = Boolean(selectedPlaces);
-  const totalNumberText = Object.keys(selectedPlaces!).length;
+  const totalNumberText = selectedPlaces!.length;
 
   return (
     <TripPlaceLayout>

--- a/src/store/AccommodationsStore.ts
+++ b/src/store/AccommodationsStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { PlaceDataType, PlacesObject } from "@/types/DataProps";
+import { PlaceDataType } from "@/types/DataProps";
 import { setTripRange } from "@/utils/setTripRange";
 
 type LocationAccommodationsStoreType = {
@@ -9,7 +9,7 @@ type LocationAccommodationsStoreType = {
 };
 
 type SelectAccommodationsStoreType = {
-  selectedAccommodations: PlacesObject | null;
+  selectedAccommodations: PlaceDataType[][] | null;
   setTripAccommodationsRange: (range: number) => void;
   // setSelectedAccommodations: (id: number) => void;
   resetSelectedAccommodations: () => void;

--- a/src/store/PlacesStore.ts
+++ b/src/store/PlacesStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { PlaceDataType, PlacesObject } from "@/types/DataProps";
+import { PlaceDataType } from "@/types/DataProps";
 import { setTripRange } from "@/utils/setTripRange";
 
 type LocationPlacesStoreType = {
@@ -9,7 +9,7 @@ type LocationPlacesStoreType = {
 };
 
 type SelectPlacesStoreType = {
-  selectedPlaces: PlacesObject | null;
+  selectedPlaces: PlaceDataType[][] | null;
   setTripPlacesRange: (range: number) => void;
   // setSelctedPlaces: (id: number) => void;
   resetSelectedPlaces: () => void;

--- a/src/types/DataProps.ts
+++ b/src/types/DataProps.ts
@@ -37,7 +37,3 @@ export type PlaceDataType = {
   title: string;
   zipcode: number;
 };
-
-export type PlacesObject = {
-  [index: number]: PlaceDataType[] | [];
-};

--- a/src/utils/setTripRange.ts
+++ b/src/utils/setTripRange.ts
@@ -1,11 +1,3 @@
-import { PlacesObject } from "@/types/DataProps";
-
 export const setTripRange = (range: number) => {
-  const newSelectedPlaces: PlacesObject = {};
-
-  for (let date = 1; date <= range; date++) {
-    newSelectedPlaces[date] = [];
-  }
-
-  return newSelectedPlaces;
+  return new Array(range).fill([]);
 };


### PR DESCRIPTION
## Overview
related #59

### 작업 내용
> 2403011 회의 내용 반영
> **데이터 로직 재변경**
> ```ts
>  // 변경: 타입 Object -> Array[][]
>  store = [
>  [선택한 장소 data들],
>  [선택한 장소 data들],
>  ...
>  ]
>  ```
>  ```ts
>  // 변경: 렌더링 방법
>  Store[index+1].map((data, index) => <{ 렌더링 컴포넌트 } />)
>  ```

- 선택한 숙소, 관광 장소 storage 재수정: `{ [index]: [데이터] }` -> `[ [데이터], [데이터], ... ]`
- 관련 TripEdit, TripPlace, TripAccommodation 페이지 컴포넌트 수정

### 달성도

- TripEdit 페이지에서 상세 경로 받아 이동할 예정입니다.
- @hyeonjuuu 님 TripDays 컴포넌트 170~176 번째 로직 내 경로에서 `index+1` route id 값만 추가해서 주시면 될거같아요! <br /> 확인 부탁드립니다 🙇🏻‍♀️🙇🏻‍♀️
  ![TripDays 컴포넌트](https://github.com/Next-WonT/WonT/assets/134567469/10f4ca0e-4012-43d8-9c51-ade43a663080)

## PR 체크리스트

- 현재 로직 변경 중으로 인해 set action 연관 로직 에러나고 있습니다.
- 로직 최종 반영 후 현주님과 상의해서 수정할 예정입니다.
