### PR TITLE
Fix: 숙소 / (관광) 장소 선택할 때, 해당 날짜에만 저장되도록 수정

### DIFF
--- a/src/store/AccommodationsStore.ts
+++ b/src/store/AccommodationsStore.ts
@@ -43,18 +43,28 @@ export const SelectAccommodationsStore = create(
             (accommodation) => accommodation.contentid === id,
           );
 
+          const newSelectedAccomodationsForDate = [
+            ...state.selectedAccommodations[date],
+          ];
+
           if (index == -1) {
             const selectAccommodation = locationAccommodations!.find(
               (accommodation) => accommodation.contentid === id,
             );
             if (selectAccommodation) {
-              state.selectedAccommodations[date].push(selectAccommodation);
+              newSelectedAccomodationsForDate.push(selectAccommodation);
             }
           } else {
-            state.selectedAccommodations[date].splice(index, 1);
+            newSelectedAccomodationsForDate.splice(index, 1);
           }
+
+          const updatedSelectedAccommodation = [
+            ...state.selectedAccommodations,
+          ];
+          updatedSelectedAccommodation[date] = newSelectedAccomodationsForDate;
+
           return {
-            selectedAccommodations: [...state.selectedAccommodations],
+            selectedAccommodations: updatedSelectedAccommodation,
           };
         }),
     }),

--- a/src/store/PlacesStore.ts
+++ b/src/store/PlacesStore.ts
@@ -28,8 +28,10 @@ export const SelectPlacesStore = create(
         set({ selectedPlaces: setTripRange(range) }),
       setSelctedPlaces: (date: number, id: number) =>
         set((state) => {
-          if (!state.selectedPlaces || !state.selectedPlaces[date]) {
+          if (!state.selectedPlaces) {
             state.selectedPlaces = [];
+          }
+          if (!state.selectedPlaces[date]) {
             state.selectedPlaces[date] = [];
           }
 
@@ -38,18 +40,24 @@ export const SelectPlacesStore = create(
             (place) => place.contentid === id,
           );
 
+          const newSelectedPlacesForDate = [...state.selectedPlaces[date]];
+
           if (index == -1) {
             const selectPlace = locationPlaces!.find(
               (place) => place.contentid === id,
             );
             if (selectPlace) {
-              state.selectedPlaces[date].push(selectPlace);
+              newSelectedPlacesForDate.push(selectPlace);
             }
           } else {
-            state.selectedPlaces[date].splice(index, 1);
+            newSelectedPlacesForDate.splice(index, 1);
           }
+
+          const updatedSelectedPlaces = [...state.selectedPlaces];
+          updatedSelectedPlaces[date] = newSelectedPlacesForDate;
+
           return {
-            selectedPlaces: [...state.selectedPlaces],
+            selectedPlaces: updatedSelectedPlaces,
           };
         }),
     }),


### PR DESCRIPTION
## Overview

Resolves, Closed: #76

### 작업 내용

- 수정 전: `state`에서 date 인덱스를 찾아 직접 연산하여 모든 날짜에 선택한 장소 저장
- 수정 후: `state[date]` 배열을 복사하여 연산 후, 새로운 배열을 state에 반환하여 해당 날짜에만 선택한 장소 저장

### 달성도

TripEdit 페이지에서 날짜 별로 선택된 저장된 장소들 렌더링됨을 확인하였습니다.

> 수정 후: TripPlace 페이지

![240312_zustand와-이중-배열_해결](https://github.com/Next-WonT/WonT/assets/134567469/beaa5cf3-bea7-40e0-b1b3-1ce9068f2834)

> 수정 후: TripEdit 페이지

![TripEdit 페이지](https://github.com/Next-WonT/WonT/assets/134567469/dc15e4ea-7fdc-4146-a395-dc1403152069)

## PR 체크리스트

- [x] 다음 사항을 읽고 포함하였습니다.

1. 코드 스타일은 프로젝트 규칙을 따릅니다.
2. 기능 구현의 경우, 코드는 문제없이 빌드 및 실행됩니다.
3. 새로운 기능을 테스트한 경우, 기존 기능에 영향을 미치지 않습니다.
4. 필요한 관련사항을 이슈템플릿에 추가하였습니다.
